### PR TITLE
fix: update neutron version to v3.0.5 for snapshot creation

### DIFF
--- a/Dockerfile.snapshot
+++ b/Dockerfile.snapshot
@@ -2,7 +2,7 @@
 
 FROM golang:1.21-bullseye
 RUN apt-get update && apt-get install -y jq curl git
-RUN git clone --branch v3.0.2 https://github.com/neutron-org/neutron.git /opt/neutron
+RUN git clone --branch v3.0.5 https://github.com/neutron-org/neutron.git /opt/neutron
 WORKDIR /opt/neutron
 
 RUN make install


### PR DESCRIPTION
With v3.0.2 release snapshot creation fails:
```
panic: Wrong app version 0, upgrade handler is missing for v3.0.5 upgrade plan
```

Updated Neutron to v3.0.5 release